### PR TITLE
Consistent with CUDA instrumentation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -34,7 +34,7 @@
 
 // constants
 constexpr int MAX_REF_LEN    =  1200;
-constexpr int MAX_QUERY_LEN  =   256;
+constexpr int MAX_QUERY_LEN  =   300;
 constexpr int BATCH_SIZE     = 50000;
 constexpr int GPU_ID         =     0;
 


### PR DESCRIPTION
- Setting the `MAX_QUERY_LEN` to `300` to make it consistent with the CUDA instrumentation (dev-instr) branch